### PR TITLE
#1：編集したノートが降順にソートされない

### DIFF
--- a/src/components/Main.jsx
+++ b/src/components/Main.jsx
@@ -8,7 +8,7 @@ const Main = ({ activeNote, onUpdateNote }) => {
     onUpdateNote({
       ...activeNote,
       [key]: value,
-      moddate: Date.now(),
+      modDate: Date.now(),
     })
   );
 


### PR DESCRIPTION
編集したノートが一番上にくるように修正しました。

原因は、タイピングミスのようです。
"modDate"になるべき箇所が"moddate"と"d"が小文字になっていました。

ご参考になれば幸いです。